### PR TITLE
Improve game room service socket

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,9 @@ import { TaskSelectionComponent } from './task-selection/task-selection.componen
 import { InformationCardsComponent } from './communication-cards/information-card.component';
 import { GameSummaryComponent } from './game-summary/game-summary.component';
 
+import { GameService } from './services/game.service';
+import { GameSummaryService } from './services/game-summary.service';
+
 @NgModule({
   declarations: [
     AppComponent,
@@ -41,7 +44,7 @@ import { GameSummaryComponent } from './game-summary/game-summary.component';
     MatSelectModule,
     MatCheckboxModule,
   ],
-  providers: [GameSummaryComponent],
+  providers: [GameService, GameSummaryService],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/game-room/game-room.component.ts
+++ b/src/app/game-room/game-room.component.ts
@@ -19,7 +19,7 @@ import {
   selector: 'app-game-room',
   templateUrl: './game-room.component.html',
   styleUrls: ['./game-room.component.sass'],
-  providers: [GameService, MatDialog],
+  providers: [MatDialog],
 })
 export class GameRoomComponent {
   cardsInHand: PlayerCard[] = [];

--- a/src/app/game-room/game-room.spec.ts
+++ b/src/app/game-room/game-room.spec.ts
@@ -4,7 +4,6 @@ import { OverlayModule } from '@angular/cdk/overlay';
 
 import { MatDialogModule } from '@angular/material/dialog';
 import { GameRoomComponent } from './game-room.component';
-import { GameService } from '../services/game.service';
 
 describe('GameRoomComponent', () => {
   let component: GameRoomComponent;
@@ -14,7 +13,6 @@ describe('GameRoomComponent', () => {
     await TestBed.configureTestingModule({
       declarations: [GameRoomComponent],
       imports: [DragDropModule, OverlayModule, MatDialogModule],
-      providers: [GameService],
     }).compileComponents();
   });
 
@@ -34,7 +32,8 @@ describe('GameRoomComponent', () => {
       { suit: 'green', value: 4, player: 4 },
     ];
     component.resolveTrick();
-    expect(component.winningCard).toEqual(winningCard);
+    const actual = component['gameSummaryService'].getWinningCard();
+    expect(actual).toEqual(winningCard);
   });
   it('should find the winning card, when trump (a rocket) is played', () => {
     const winningCard = { suit: 'rocket', value: 1, player: 2 };
@@ -46,7 +45,8 @@ describe('GameRoomComponent', () => {
       { suit: 'green', value: 4, player: 4 },
     ];
     component.resolveTrick();
-    expect(component.winningCard).toEqual(winningCard);
+    const actual = component['gameSummaryService'].getWinningCard();
+    expect(actual).toEqual(winningCard);
   });
   it("should find the winning card, when players can't follow the lead suit", () => {
     const winningCard = { suit: 'pink', value: 1, player: 1 };
@@ -58,7 +58,8 @@ describe('GameRoomComponent', () => {
       { suit: 'yellow', value: 4, player: 4 },
     ];
     component.resolveTrick();
-    expect(component.winningCard).toEqual(winningCard);
+    const actual = component['gameSummaryService'].getWinningCard();
+    expect(actual).toEqual(winningCard);
   });
 
   it('should prevent dragging to players hand if they have communicated', () => {

--- a/src/app/task-selection/task-selection.component.ts
+++ b/src/app/task-selection/task-selection.component.ts
@@ -21,7 +21,6 @@ enum RelativeOrder {
   selector: 'app-task-selection',
   templateUrl: './task-selection.component.html',
   styleUrls: ['./task-selection.component.sass'],
-  providers: [GameService],
 })
 export class TaskSelectionComponent implements OnInit {
   @Input() isPlayerCommander = false;


### PR DESCRIPTION
Change game service that creates the socket connection to a root level service. Thereby creating one instance of the service and only one socket per client, without the need of using ngZone and ngZone.run()